### PR TITLE
Calls to controllers should not be statically made

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -6,7 +6,7 @@ use App\Models\Student;
 
 class AttendanceController
 {
-    static function index(): void
+    public function index(): void
     {
         $title = 'Prendre les présences';
         $students = Student::getAllStudents();

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 class PageController
 {
-    static function home(): void
+    public function home(): void
     {
         $title = 'Page d’accueil';
         view('home', compact('title'));

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -6,7 +6,7 @@ use App\Models\Student;
 
 class StudentController
 {
-    static function index(): void
+    public function index(): void
     {
         $title = 'Tous les étudiants';
         $students = Student::getAllStudents();


### PR DESCRIPTION
Les appels statiques de méthodes peuvent rendre la lecture du code plus évidente et diminuer le boilerplate requis, mais ils nuisent à beaucoup d'autres qualités d'un architecture logicielle et il faut les réserver uniquement à des scénarios justifiés.
