### PR TITLE
It should not be possible to make cross site requests to post endpoints

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,8 @@
 
 use tecgdcs\Router;
 
+session_start();
+
 require __DIR__ . '/../bootstrap/app.php';
 
 require VENDOR_PATH . '/autoload.php';

--- a/tecgdcs/helpers.php
+++ b/tecgdcs/helpers.php
@@ -64,3 +64,14 @@ if (!function_exists('view')) {
 
     }
 }
+
+if (!function_exists('csrf_token')) {
+    function csrf_token(int $length = 32): string
+    {
+        if (!isset($_SESSION['token'])) {
+            $_SESSION['token'] = bin2hex(random_bytes($length));
+        }
+
+        return $_SESSION['token'];
+    }
+}


### PR DESCRIPTION
Pour le moment, les accès aux routes de soumission de données avec des formulaires peuvent être atteintes depuis n'importe quel client. Nous allons utiliser un token csrf pour limiter les requêtes valides au seul client que nous voulons autoriser, notre formulaire.
